### PR TITLE
CZ - Resolve Documents page refresh bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,20 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RapidRecall - Dashboard</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafgraph/spa-github-pages
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) {
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>RapidMD</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment
+      var pathSegmentsToKeep = 0; // starts at 0 for root-level deployment (custom domain)
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -4,7 +4,7 @@ import { Button } from '../components/Button';
 import { FileText, Upload, AlertCircle, CheckCircle } from 'lucide-react';
 import { auth } from '../lib/firebase';
 
-const BACKEND_URL = 'http://localhost:8080' || "https://rapidrecall-production.up.railway.app";
+const BACKEND_URL = 'https://rapidrecall-production.up.railway.app' || 'http://localhost:8080';
 
 export function Documents({ user }) {
   const [selectedFile, setSelectedFile] = useState(null);

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -3,7 +3,7 @@ import { signInWithPopup } from 'firebase/auth';
 import { auth, googleProvider } from '../lib/firebase';
 import { useNavigate } from 'react-router-dom';
 
-const BACKEND_URL = "https://rapidrecall-production.up.railway.app" || 'http://localhost:8080';
+const BACKEND_URL = 'https://rapidrecall-production.up.railway.app' || 'http://localhost:8080';
 
 export function Login() {
   const navigate = useNavigate();


### PR DESCRIPTION
Since Github Pages serves static sites without React routing, any subpage wasn't persisting upon refresh (404 error). I added Single Page Application routing for Github Pages using the solution from https://github.com/rafgraph/spa-github-pages. 

Previous bug:
<img width="1440" height="834" alt="Screenshot 2025-11-22 at 4 07 49 PM" src="https://github.com/user-attachments/assets/805433f1-c9f0-4348-8f48-ec713b25dd90" />
