### PR TITLE
JL - Regular User Access to Recalls / Updates to Recall Database / View PDF

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,8 @@ function getPageTitle(pathname, user) {
       return 'RapidMD - Manage Users';
     case '/admin/recalls':
       return 'RapidMD - Manage Recalls';
+    case '/my-recalls':
+      return 'RapidMD - My Recalls';
     case '/documents':
       return 'RapidMD - Documents';
     default:
@@ -147,6 +149,10 @@ function AppContent() {
           <Route 
             path="/admin/recalls" 
             element={userRole === 'admin' ? <RecallsDatabase /> : <Navigate to="/" replace />} 
+          />
+          <Route 
+            path="/my-recalls" 
+            element={userRole !== 'admin' ? <RecallsDatabase /> : <Navigate to="/admin/recalls" replace />} 
           />
           <Route path="/documents" element={<Documents user={user} />} />
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -8,6 +8,10 @@ const baseNavigation = [
   { name: 'Settings', href: '/settings', icon: Settings },
 ];
 
+const userNavigation = [
+  { name: 'My Recalls', href: '/my-recalls', icon: Database },
+];
+
 const adminNavigation = [
   { name: 'Manage Users', href: '/admin/users', icon: Users },
   { name: 'Manage Recalls', href: '/admin/recalls', icon: Database },
@@ -19,7 +23,7 @@ export function Sidebar({ user, userRole, onSignOut }) {
   // Combine navigation items based on user role
   const navigation = userRole === 'admin' 
     ? [...baseNavigation, ...adminNavigation]
-    : baseNavigation;
+    : [...baseNavigation, ...userNavigation];
 
   return (
     <div className="flex flex-col h-screen w-64 bg-white border-r border-gray-200">


### PR DESCRIPTION
Regular users can now view their submitted recalls:
<img width="1698" height="970" alt="Screenshot 2026-01-21 at 1 19 33 PM" src="https://github.com/user-attachments/assets/2cd30c72-956b-40a7-9c16-d6f613705cec" />

Sort recalls by date:
<img width="442" height="610" alt="Screenshot 2026-01-21 at 1 28 43 PM" src="https://github.com/user-attachments/assets/7c22d6cf-42a0-4245-beb2-12eb6e258c19" />

Sort recalls by classification:
<img width="442" height="610" alt="Screenshot 2026-01-21 at 1 28 54 PM" src="https://github.com/user-attachments/assets/822d59b6-dd9d-42da-997c-7e8bf69a868c" />

Admins can view all recalls or filter by their own submissions:
<img width="1698" height="970" alt="Screenshot 2026-01-21 at 1 20 31 PM" src="https://github.com/user-attachments/assets/d5a89225-ebad-47df-8816-1d2afee615c1" />
<img width="1698" height="970" alt="Screenshot 2026-01-21 at 1 20 41 PM" src="https://github.com/user-attachments/assets/8aef67fb-f00b-4bb6-8c03-24c1c6986f98" />

[wip] Additionally, users will have the option to view pdf submission via Firebase url (permissions still need to be set)
<img width="1323" height="511" alt="Screenshot 2026-01-21 at 1 32 22 PM" src="https://github.com/user-attachments/assets/199d514e-2765-4a45-9db1-5ebae6f991a1" />

Closes #13 